### PR TITLE
Fix typo: Infos -> Info in PHPDoc comments

### DIFF
--- a/src/Core/AppSystems/CtrlRouterLink.php
+++ b/src/Core/AppSystems/CtrlRouterLink.php
@@ -5,7 +5,7 @@ namespace BFW\Core\AppSystems;
 class CtrlRouterLink extends AbstractSystem
 {
     /**
-     * @var object $ctrlRouterInfos Infos from router for controller
+     * @var object $ctrlRouterInfos Info from router for controller
      * system
      */
     protected $ctrlRouterInfos;

--- a/src/Core/Errors.php
+++ b/src/Core/Errors.php
@@ -72,7 +72,7 @@ class Errors
      *
      * @return boolean|array Render infos
      *  Boolean : false if no render to use
-     *  Array   : Infos from config
+     *  Array   : Info from config
      */
     protected function obtainErrorRender()
     {
@@ -90,7 +90,7 @@ class Errors
      *
      * @return boolean|array Render infos
      *  Boolean : false if no render to use
-     *  Array   : Infos from config
+     *  Array   : Info from config
      */
     protected function obtainExceptionRender()
     {
@@ -214,7 +214,7 @@ class Errors
      * Call the personnal class-method or function declared on config when
      * an exception or an error is triggered.
      *
-     * @param array    $renderInfos : Infos from config
+     * @param array    $renderInfos : Info from config
      * @param string   $errType : Human readable error severity
      * @param string   $errMsg : Error/exception message
      * @param string   $errFile : File where the error/exception is triggered

--- a/src/Helpers/Form.php
+++ b/src/Helpers/Form.php
@@ -60,7 +60,7 @@ class Form
     /**
      * Save the form's token
      *
-     * @param object $saveInfos Infos about token (id and expire time)
+     * @param object $saveInfos Info about token (id and expire time)
      *
      * @return void
      */
@@ -75,7 +75,7 @@ class Form
      *
      * @global array $_SESSION
      *
-     * @param object $saveInfos Infos about token (id and expire time)
+     * @param object $saveInfos Info about token (id and expire time)
      *
      * @return void
      */


### PR DESCRIPTION
Fixes #100

Changed "Infos" to "Info" in PHPDoc comments across 3 files:
- src/Core/AppSystems/CtrlRouterLink.php
- src/Core/Errors.php
- src/Helpers/Form.php

This is a documentation typo fix - no code logic was changed.